### PR TITLE
Feature/add timeouts to http adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This gem is a Ruby-Cucumber formatter which sends the test output to [Report Portal](https://reportportal.io).
 
-This formatter supports plain 'ol Cucumber tests and those wrapped with [parallel_tests](https://rubygems.org/gems/parallel_tests). 
+This formatter supports plain 'ol Cucumber tests and those wrapped with [parallel_tests](https://rubygems.org/gems/parallel_tests).
 
 It also supports Cucumber 3.x and 4+ (Cucumber implementations using cucumber-messages).
 
@@ -30,20 +30,30 @@ The formatter supports configuration via a config file or via environment variab
 
 #### Configuration file
 
-It will search for a file called `report_portal.yml` or `REPORT_PORTAL.YML` in `./config` and `./`. It expects this file to contain the standard Report Portal configuration options -- see the Report Portal documentation. Optionally, the config file keys may match those accepted through environment variables -- they may contain 'rp_' and 'RP_'.
+It will search for a file called `report_portal.yml` or `REPORT_PORTAL.YML` in `./config` and `./`. It expects this file to contain the standard Report Portal configuration options -- see the Report Portal documentation. Optionally, the config file keys may match those accepted through environment variables -- they may contain 'rp*' and 'RP*'.
+
+#### Configurable Timeouts
+
+When running in parallel you might encounter some connection timeouts and these have been made configurable. You can configure the Report Portal yaml file with these attributes and set your own custom timeout values.
+
+```yaml
+idle_timeout: 100
+open_timeout: 60
+read_timeout: 60
+```
 
 #### Environment variables
 
 It will search for the following environment variables which may be in upper or lowercase (the official client defers to lower case, this is available here for compatibility).
 
-* `RP_UUID` - the user's UUID for this Report Portal instance which must be created in advance
-* `RP_ENDPOINT` - the endpoint for this Report Portal instance 
-* `RP_PROJECT` - the Report Portal project name which must be created in advance and this user added as a member 
-* `RP_LAUNCH` - the name of this 'launch'  
-* `RP_DEBUG` - *optional* if set to the string value `true` it will instruct Report Portal to add the output of these tests to the debug tab 
-* `RP_DESCRIPTION` - *optional* a textual description of the launch 
-* `RP_TAGS` - *optional* a string of comma separated tags 
-* `RP_ATTRIBUTES` - *optional* a string of comma separated attributes 
+- `RP_UUID` - the user's UUID for this Report Portal instance which must be created in advance
+- `RP_ENDPOINT` - the endpoint for this Report Portal instance
+- `RP_PROJECT` - the Report Portal project name which must be created in advance and this user added as a member
+- `RP_LAUNCH` - the name of this 'launch'
+- `RP_DEBUG` - _optional_ if set to the string value `true` it will instruct Report Portal to add the output of these tests to the debug tab
+- `RP_DESCRIPTION` - _optional_ a textual description of the launch
+- `RP_TAGS` - _optional_ a string of comma separated tags
+- `RP_ATTRIBUTES` - _optional_ a string of comma separated attributes
 
 ### With cucumber
 
@@ -61,9 +71,7 @@ cucumber -f ParallelReportPortal::Cucumber::Formatter --out /dev/null -f progres
 
 ```
 parallel_cucumber -- -f ParallelReportPortal::Cucumber::Formatter -- features/
- ```
-
-
+```
 
 ## Development
 

--- a/lib/parallel_report_portal/configuration.rb
+++ b/lib/parallel_report_portal/configuration.rb
@@ -22,7 +22,7 @@ module ParallelReportPortal
   # RP_TAGS:: A set of tags to pass to Report Portal for this launch. If these are set via an environment variable, provide a comma-separated string of tags
   # RP_ATTRIBUTES:: A set of attribute tags to pass to Report Portal for this launch. If these are set via an environment variable, provide a comma-separated string of attributes
   class Configuration
-    ATTRIBUTES = [:uuid, :endpoint, :project, :launch, :debug, :description, :tags, :attributes]
+    ATTRIBUTES = [:uuid, :endpoint, :project, :launch, :debug, :description, :tags, :attributes, :open_timeout, :idle_timeout, :read_timeout]
 
     # @return [String] the Report Portal user UUID
     attr_accessor :uuid
@@ -45,6 +45,12 @@ module ParallelReportPortal
     # @return [Array<String>] an array of attributes to attach to this launch
     #   (Report Portal 5)
     attr_reader :attributes
+    # @return [Integer] the number of seconds for the open connection to timeout
+    attr_accessor :open_timeout
+    # @return [Integer] the number of seconds for the open and idle connection to timeout
+    attr_accessor :idle_timeout
+    # @return [Integer] the number of seconds for the read connection to timeout
+    attr_accessor :read_timeout
 
 
     # Create an instance of Configuration.
@@ -93,6 +99,12 @@ module ParallelReportPortal
                else
                  value.to_s.downcase.strip == 'true'
                end
+    end
+
+    # Simple method to obtain an attribute from this class or set default value
+    # param [symbol] a symbol version of the attribute
+    def fetch(key, default_value)
+      self.send(key).nil? ? default_value : self.send(key)
     end
 
     # Sets the attributes for the launch. If an array is provided, the array is used,

--- a/lib/parallel_report_portal/http.rb
+++ b/lib/parallel_report_portal/http.rb
@@ -39,7 +39,9 @@ module ParallelReportPortal
         }
       ) do |f|
         f.adapter :net_http_persistent, pool_size: 5 do |http|
-          http.idle_timeout = 100
+          http.idle_timeout = ParallelReportPortal.configuration.fetch(:idle_timeout, 100)
+          http.open_timeout = ParallelReportPortal.configuration.fetch(:open_timeout, 60)
+          http.read_timeout = ParallelReportPortal.configuration.fetch(:read_timeout, 60)
         end
       end
     end
@@ -60,7 +62,9 @@ module ParallelReportPortal
         conn.request :url_encoded
         conn.adapter :net_http_persistent, pool_size: 5 do |http|
           # yields Net::HTTP::Persistent
-          http.idle_timeout = 100
+          http.idle_timeout = ParallelReportPortal.configuration.fetch(:idle_timeout, 100)
+          http.open_timeout = ParallelReportPortal.configuration.fetch(:open_timeout, 60)
+          http.read_timeout = ParallelReportPortal.configuration.fetch(:read_timeout, 60)
         end
       end
     end

--- a/lib/parallel_report_portal/version.rb
+++ b/lib/parallel_report_portal/version.rb
@@ -1,3 +1,3 @@
 module ParallelReportPortal
-  VERSION = "2.0.3"
+  VERSION = "2.1.0"
 end

--- a/spec/parallel_report_portal/configuration_spec.rb
+++ b/spec/parallel_report_portal/configuration_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ParallelReportPortal::Configuration do
     let(:configurable_attributes) { ParallelReportPortal::Configuration::ATTRIBUTES }
 
     it 'reflects over the settable attributes' do
-      expected_attrs = [:uuid, :endpoint, :project, :launch, :debug, :description, :tags, :attributes]
+      expected_attrs = [:uuid, :endpoint, :project, :launch, :debug, :description, :tags, :attributes, :open_timeout, :idle_timeout, :read_timeout]
       expect(configurable_attributes).to contain_exactly(*expected_attrs)
     end
   end
@@ -45,6 +45,15 @@ RSpec.describe ParallelReportPortal::Configuration do
       description = 'this is a launch description'
       config.description = description
       expect(config.description).to eq(description)
+    end
+
+    it 'allows configuration of timeouts' do
+      config.idle_timeout = 23
+      config.open_timeout = 23
+      config.read_timeout = 23
+      expect(config.idle_timeout).to eq(23)
+      expect(config.open_timeout).to eq(23)
+      expect(config.read_timeout).to eq(23)
     end
 
     context 'handles array-like strings and arrays' do


### PR DESCRIPTION
Added default timeouts on the Faraday adapter - Allowed the timeouts to be configurable via the report portal config yaml

Sometimes when running in parallel you can hit some timeout errors and this change is to allow the timeouts to be configurable if the default is not long enough and avoid failed builds/results going to ReportPortal