### PR TITLE
Explicitly pass scenario_id to http.send_file()

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --require spec_helper
+--format documentation


### PR DESCRIPTION
I have been using this method to send log files to Report Portal and they re mostly, but not always being attached the the scenario that ran just before the one they belong to.

It is hoped that this change will allow us to specify the ID of the scenario they belong to.

I think I also managed to improve the tests for the `http.send_file()` method while I was working on it.