### PR TITLE
Send scenario_id as itemUuid when uploading attachments

### DIFF
--- a/lib/parallel_report_portal/http.rb
+++ b/lib/parallel_report_portal/http.rb
@@ -192,7 +192,7 @@ module ParallelReportPortal
     def req_log(test_case_id, detail, level, time)
       resp = ParallelReportPortal.http_connection.post('log') do |req|
         req.body = {
-          item_id: test_case_id,
+          itemUuid: test_case_id,
           message: detail,
           level: level,
           time: time,
@@ -221,7 +221,15 @@ module ParallelReportPortal
 
         # where did @test_case_id come from? ok, I know where it came from but this
         # really should be factored out of here and state handled better
-        json = { level: status, message: label, item_id: scenario_id || @test_case_id, time: time, file: { name: File.basename(file) } }
+        json = {
+          level: status,
+          message: label,
+          itemUuid: scenario_id || @test_case_id,
+          time: time,
+          file: {
+            name: File.basename(file)
+          }
+        }
 
         json_file = Tempfile.new
         json_file << [json].to_json

--- a/spec/parallel_report_portal/http_spec.rb
+++ b/spec/parallel_report_portal/http_spec.rb
@@ -179,7 +179,7 @@ RSpec.describe ParallelReportPortal::HTTP do
       rp.req_log(item_id, 'a message', 'info', time)
       expect(WebMock).to have_requested(:post, "#{rp_endpoint}/log")
         .with( body: {
-          item_id: item_id,
+          itemUuid: item_id,
           message: 'a message',
           level: 'info',
           time: time
@@ -194,7 +194,7 @@ RSpec.describe ParallelReportPortal::HTTP do
 
       expect_log_endpoint_called_with_body_part('"level":"info"')
       expect_log_endpoint_called_with_body_part('"message":"a label"')
-      expect_log_endpoint_called_with_body_part('"item_id":null')
+      expect_log_endpoint_called_with_body_part('"itemUuid":null')
       expect_log_endpoint_called_with_body_part('"time":null')
       expect_log_endpoint_called_with_body_part("\"file\":{\"name\":\"#{File.basename(temp_file.path)}\"}")
     end
@@ -207,7 +207,7 @@ RSpec.describe ParallelReportPortal::HTTP do
 
       expect_log_endpoint_called_with_body_part('"level":"info"')
       expect_log_endpoint_called_with_body_part('"message":"a label"')
-      expect_log_endpoint_called_with_body_part('"item_id":"cfbf75de-dafe-4a4e-a681-c5cb5026cb93"')
+      expect_log_endpoint_called_with_body_part('"itemUuid":"cfbf75de-dafe-4a4e-a681-c5cb5026cb93"')
       expect_log_endpoint_called_with_body_part('"time":null')
       expect_log_endpoint_called_with_body_part("\"file\":{\"name\":\"#{File.basename(temp_file.path)}\"}")
     end


### PR DESCRIPTION
This is based on information from https://github.com/reportportal/reportportal/issues/1831 and https://github.com/reportportal/documentation/blob/master/src/md/src/DevGuides/reporting.md#batch-save-logs