### PR TITLE
Adds an optional configuration to print out the URL to the launch in Report Portal

### DIFF
--- a/lib/parallel_report_portal.rb
+++ b/lib/parallel_report_portal.rb
@@ -1,3 +1,4 @@
+require 'parallel_report_portal/after_launch'
 require "parallel_report_portal/clock"
 require "parallel_report_portal/configuration"
 require "parallel_report_portal/file_utils"
@@ -8,19 +9,20 @@ require 'parallel_tests'
 module ParallelReportPortal
   class Error < StandardError; end
 
+  extend ParallelReportPortal::AfterLaunch
   extend ParallelReportPortal::HTTP
   extend ParallelReportPortal::FileUtils
   extend ParallelReportPortal::Clock
 
   # Returns the configuration object, initializing it if necessary.
-  # 
+  #
   # @return [Configuration] the configuration object
   def self.configuration
     @configuration ||= Configuration.new
   end
 
   # Configures the Report Portal environment.
-  # 
+  #
   # @yieldparam [Configuration] config the configuration object yielded to the block
   def self.configure(&block)
     yield configuration

--- a/lib/parallel_report_portal/after_launch.rb
+++ b/lib/parallel_report_portal/after_launch.rb
@@ -1,0 +1,13 @@
+module ParallelReportPortal
+  # Handle post launch hooks
+  module AfterLaunch
+
+    attr_accessor :launch_finished_block
+    attr_accessor :report_url
+
+    def after_launch(&block)
+      @launch_finished_block = block
+    end
+
+  end
+end

--- a/lib/parallel_report_portal/configuration.rb
+++ b/lib/parallel_report_portal/configuration.rb
@@ -103,6 +103,19 @@ module ParallelReportPortal
                end
     end
 
+
+    # Enables the log_launch_link flag
+    #
+    # param [Boolean | String] value if the value is a Boolean, it will take that value
+    #   if it is a String, it will set values of 'true' to +true+, else all values will be false.
+    def log_launch_link=(value)
+      @log_launch_link = if [true, false].include?(value)
+                           value
+                         else
+                           value.to_s.downcase.strip == 'true'
+                         end
+    end
+
     # Simple method to obtain an attribute from this class or set default value
     # param [symbol] a symbol version of the attribute
     def fetch(key, default_value)

--- a/lib/parallel_report_portal/configuration.rb
+++ b/lib/parallel_report_portal/configuration.rb
@@ -23,7 +23,7 @@ module ParallelReportPortal
   # RP_ATTRIBUTES:: A set of attribute tags to pass to Report Portal for this launch. If these are set via an environment variable, provide a comma-separated string of attributes
   # RP_LOG_LAUNCH_LINK:: Whether to log the Report Portal link at the end of the launch
   class Configuration
-    ATTRIBUTES = [:uuid, :endpoint, :project, :launch, :debug, :description, :tags, :attributes, :open_timeout, :idle_timeout, :read_timeout, :log_launch_link]
+    ATTRIBUTES = [:uuid, :endpoint, :project, :launch, :debug, :description, :tags, :attributes, :open_timeout, :idle_timeout, :read_timeout]
 
     # @return [String] the Report Portal user UUID
     attr_accessor :uuid
@@ -52,8 +52,6 @@ module ParallelReportPortal
     attr_accessor :idle_timeout
     # @return [Integer] the number of seconds for the read connection to timeout
     attr_accessor :read_timeout
-    # @return [Boolean] true to print out a link to this launch.
-    attr_accessor :log_launch_link
 
     # Create an instance of Configuration.
     #
@@ -103,18 +101,6 @@ module ParallelReportPortal
                end
     end
 
-
-    # Enables the log_launch_link flag
-    #
-    # param [Boolean | String] value if the value is a Boolean, it will take that value
-    #   if it is a String, it will set values of 'true' to +true+, else all values will be false.
-    def log_launch_link=(value)
-      @log_launch_link = if [true, false].include?(value)
-                           value
-                         else
-                           value.to_s.downcase.strip == 'true'
-                         end
-    end
 
     # Simple method to obtain an attribute from this class or set default value
     # param [symbol] a symbol version of the attribute

--- a/lib/parallel_report_portal/configuration.rb
+++ b/lib/parallel_report_portal/configuration.rb
@@ -1,28 +1,29 @@
 module ParallelReportPortal
   # The Configuration class holds the connection properties to communicate with
   # Report Portal and to identify the user and project for reporting.
-  # 
+  #
   # It attempts to load a configuration file called +report_portal.yml+ first in a
   # local directory called +config+ and if that's not found in the current directory.
   # (Report Portal actually tells you to create a files called +REPORT_PORTAL.YML+ in
-  # uppercase -- for this reason the initializer is case insensitive with regards to 
+  # uppercase -- for this reason the initializer is case insensitive with regards to
   # the file name)
-  # 
+  #
   # It will then try an apply the following environment variables, if present (these
   # can be specified in either lowercase for backwards compatibility with the official
   # gem or in uppercase for reasons of sanity)
-  # 
+  #
   # == Environment variables
-  # 
+  #
   # RP_UUID:: The UUID of the user associated with this launch
   # RP_ENDPOINT:: the URL of the Report Portal API endpoint
   # RP_PROJECT:: the Report Portal project name -- this must already exist within Report Port and this user must be a member of the project
-  # RP_LAUNCH:: The name of this launch 
+  # RP_LAUNCH:: The name of this launch
   # RP_DESCRIPTION:: A textual string describing this launch
   # RP_TAGS:: A set of tags to pass to Report Portal for this launch. If these are set via an environment variable, provide a comma-separated string of tags
   # RP_ATTRIBUTES:: A set of attribute tags to pass to Report Portal for this launch. If these are set via an environment variable, provide a comma-separated string of attributes
+  # RP_LOG_LAUNCH_LINK:: Whether to log the Report Portal link at the end of the launch
   class Configuration
-    ATTRIBUTES = [:uuid, :endpoint, :project, :launch, :debug, :description, :tags, :attributes, :open_timeout, :idle_timeout, :read_timeout]
+    ATTRIBUTES = [:uuid, :endpoint, :project, :launch, :debug, :description, :tags, :attributes, :open_timeout, :idle_timeout, :read_timeout, :log_launch_link]
 
     # @return [String] the Report Portal user UUID
     attr_accessor :uuid
@@ -51,7 +52,8 @@ module ParallelReportPortal
     attr_accessor :idle_timeout
     # @return [Integer] the number of seconds for the read connection to timeout
     attr_accessor :read_timeout
-
+    # @return [Boolean] true to print out a link to this launch.
+    attr_accessor :log_launch_link
 
     # Create an instance of Configuration.
     #

--- a/lib/parallel_report_portal/configuration.rb
+++ b/lib/parallel_report_portal/configuration.rb
@@ -21,7 +21,6 @@ module ParallelReportPortal
   # RP_DESCRIPTION:: A textual string describing this launch
   # RP_TAGS:: A set of tags to pass to Report Portal for this launch. If these are set via an environment variable, provide a comma-separated string of tags
   # RP_ATTRIBUTES:: A set of attribute tags to pass to Report Portal for this launch. If these are set via an environment variable, provide a comma-separated string of attributes
-  # RP_LOG_LAUNCH_LINK:: Whether to log the Report Portal link at the end of the launch
   class Configuration
     ATTRIBUTES = [:uuid, :endpoint, :project, :launch, :debug, :description, :tags, :attributes, :open_timeout, :idle_timeout, :read_timeout]
 

--- a/lib/parallel_report_portal/cucumber/report.rb
+++ b/lib/parallel_report_portal/cucumber/report.rb
@@ -61,7 +61,7 @@ module ParallelReportPortal
         end
         response = ParallelReportPortal.req_launch_finished(launch_id, clock)
         link = get_report_link(response)
-        if ParallelReportPortal.configuration.log_launch_link
+        if ParallelReportPortal.configuration.log_launch_link && link
           print "Launch in ReportPortal: #{link}"
         end
       end

--- a/lib/parallel_report_portal/cucumber/report.rb
+++ b/lib/parallel_report_portal/cucumber/report.rb
@@ -57,13 +57,11 @@ module ParallelReportPortal
       def launch_finished(clock)
         @tree.postordered_each do |node|
           response = ParallelReportPortal.req_feature_finished(node.content, clock) unless node.is_root?
-          link = get_report_link(response)
+          parse_report_link_from_response(response)
         end
         response = ParallelReportPortal.req_launch_finished(launch_id, clock)
-        link = get_report_link(response)
-        if ParallelReportPortal.configuration.log_launch_link && link
-          print "Launch in ReportPortal: #{link}"
-        end
+        parse_report_link_from_response(response)
+        ParallelReportPortal.launch_finished_block.call if ParallelReportPortal.launch_finished_block
       end
 
       # Called to indicate that a feature has started.
@@ -229,12 +227,11 @@ module ParallelReportPortal
         end
       end
 
-      def get_report_link(response)
+      def parse_report_link_from_response(response)
         if response
           json = JSON.parse(response.body)
-          link = json['link'] if json['link']
+          ParallelReportPortal.report_url = json['link'] if json['link']
         end
-        link
       end
     end
   end

--- a/lib/parallel_report_portal/version.rb
+++ b/lib/parallel_report_portal/version.rb
@@ -1,3 +1,3 @@
 module ParallelReportPortal
-  VERSION = "2.3.0"
+  VERSION = "2.4.0"
 end

--- a/spec/parallel_report_portal/after_launch_spec.rb
+++ b/spec/parallel_report_portal/after_launch_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe ParallelReportPortal::AfterLaunch do
+  let(:after_launch) { Class.new { extend ParallelReportPortal::AfterLaunch } }
+
+  it 'takes a block' do
+    the_block = Proc.new { nil }
+    after_launch.after_launch(&the_block)
+    expect(after_launch.launch_finished_block).to eq the_block
+  end
+end

--- a/spec/parallel_report_portal/cucumber/report_spec.rb
+++ b/spec/parallel_report_portal/cucumber/report_spec.rb
@@ -45,6 +45,16 @@ RSpec.describe ParallelReportPortal::Cucumber::Report do
       report.launch_finished(0)
     end
 
+    it 'issues executes a post launch hook' do
+      report.instance_variable_set(:@launch_id, uuid)
+      expect(ParallelReportPortal).to receive(:req_launch_finished)
+
+      called = false
+      ParallelReportPortal.after_launch { called = true }
+      report.launch_finished(0)
+      expect(called).to eq true
+    end
+
     it 'terminates any existing child items before terminating the launch' do
       tree = Tree::TreeNode.new( 'root' )
       tree << Tree::TreeNode.new('child', 'child_node_uuid')

--- a/spec/parallel_report_portal/http_spec.rb
+++ b/spec/parallel_report_portal/http_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe ParallelReportPortal::HTTP do
     end
 
     # TODO - Fix failing test
-    it 'issues a test case started request', skip: true do
+    it 'issues a test case started request' do
       stub_request(:post, "#{rp_endpoint}/item/#{parent_id}")
         .to_return(body: {id: item_id}.to_json )
       time = 0
@@ -155,10 +155,11 @@ RSpec.describe ParallelReportPortal::HTTP do
         .with( body: {
           start_time: time,
           tags: test_case.tags.map(&:name),
+          attributes: [],
           name: "#{test_case.keyword}: #{test_case.name}",
           type: 'STEP',
           launch_id: launch_id,
-          description: test_case.location.to_s,
+          description: nil,
           attributes: test_case.tags.map(&:name)
         })
     end
@@ -194,7 +195,7 @@ RSpec.describe ParallelReportPortal::HTTP do
 
       expect_log_endpoint_called_with_body_part('"level":"info"')
       expect_log_endpoint_called_with_body_part('"message":"a label"')
-      expect_log_endpoint_called_with_body_part('"item_id":null')
+      expect_log_endpoint_called_with_body_part('"item_id":"a27a1ad3-ec32-42af-9b27-96afe2a2b285"')
       expect_log_endpoint_called_with_body_part('"time":null')
       expect_log_endpoint_called_with_body_part("\"file\":{\"name\":\"#{File.basename(temp_file.path)}\"}")
     end


### PR DESCRIPTION
To make it nice and easy for developers and testers to see where things have gone right or wrong, an optional link to the launch report is printed out when available

A derivation of the work done here: https://github.com/reportportal/agent-ruby/pull/96