### PR TITLE
Update faraday to v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 /pkg/
 /spec/reports/
 /tmp/
+/out/
+/vendor/
 
 # Appraisal lock files
 /gemfiles/*.lock
@@ -15,5 +17,6 @@ Gemfile.lock
 # rspec failure tracking
 .rspec_status
 .DS_Store
+.ruby-version
 
 *.gem

--- a/lib/parallel_report_portal/cucumber/report.rb
+++ b/lib/parallel_report_portal/cucumber/report.rb
@@ -1,4 +1,6 @@
 require 'faraday'
+require 'faraday/net_http_persistent'
+require 'faraday/multipart'
 require 'tree'
 
 module ParallelReportPortal
@@ -27,6 +29,13 @@ module ParallelReportPortal
         @feature = nil
         @tree = Tree::TreeNode.new( 'root' )
         @ast_lookup = ast_lookup
+        check_faraday_compatibility
+      end
+
+      def check_faraday_compatibility
+        if Gem::Version.create(Faraday::VERSION) < Gem::Version.create('2.0')
+          Kernel.warn("Minimum of Faraday v2 is expected for compatibility with parallel_report_portal", category: :deprecated)
+        end
       end
 
       # Issued to start a launch. It is possilbe that this method could be called

--- a/lib/parallel_report_portal/version.rb
+++ b/lib/parallel_report_portal/version.rb
@@ -1,3 +1,3 @@
 module ParallelReportPortal
-  VERSION = "2.4.0"
+  VERSION = "2.5.0"
 end

--- a/parallel_report_portal.gemspec
+++ b/parallel_report_portal.gemspec
@@ -38,7 +38,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "webmock", "~> 3.12"
   
   spec.add_runtime_dependency 'cucumber', '>= 3.2'
-  spec.add_runtime_dependency 'faraday', '~> 1.0'
+  spec.add_runtime_dependency 'faraday-net_http_persistent', '~> 2.1'
+  spec.add_runtime_dependency 'faraday-multipart', '~> 1.0', '>= 1.0.4'
   spec.add_runtime_dependency 'parallel_tests', '>= 2.29.1'
   spec.add_runtime_dependency 'rubytree', '~> 1.0'
   spec.add_runtime_dependency 'net-http-persistent', '~> 4.0'

--- a/spec/parallel_report_portal/http_spec.rb
+++ b/spec/parallel_report_portal/http_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe ParallelReportPortal::HTTP do
           'Content-Type' => 'application/json'
         })
 
-        expect(conn.builder.handlers).not_to include(Faraday::Request::Multipart, Faraday::Request::UrlEncoded)
+        expect(conn.builder.handlers).not_to include(Faraday::Multipart::Middleware, Faraday::Request::UrlEncoded)
       end
 
       it 'uses a persistent HTTP adapter' do
@@ -59,7 +59,7 @@ RSpec.describe ParallelReportPortal::HTTP do
           'Content-Type' => 'application/json'
         })
 
-        expect(conn.builder.handlers).to include(Faraday::Request::Multipart, Faraday::Request::UrlEncoded)
+        expect(conn.builder.handlers).to include(Faraday::Multipart::Middleware, Faraday::Request::UrlEncoded)
       end
 
       it 'uses a persistent HTTP adapter' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,8 @@ require 'webmock/rspec'
 
 require 'cucumber'
 require 'faraday'
+require 'faraday/net_http_persistent'
+require 'faraday/multipart'
 require 'ostruct'
 require 'tree'
 require 'yaml'


### PR DESCRIPTION
# Why
Other common and client gems have moved to using faraday v2 so consuming projects face a clash when using report portal

# what
Update middleware for faraday-net_http_persistent (and its dependency on faraday v2.5+) and faraday-multipart 
Update relevant class references

# testing
Spec tests have been updated and are fully passing
Locally built gem has been included in a consuming application test suite and local feature test run has appeared correctly within hosted report portal instance. Before and after runs are available in instance for review and comparison.
