### PR TITLE
Apply fix for unexpected eof when running against OpenSSL v3

### DIFF
--- a/lib/parallel_report_portal.rb
+++ b/lib/parallel_report_portal.rb
@@ -1,3 +1,4 @@
+require 'openssl'
 require 'parallel_report_portal/after_launch'
 require "parallel_report_portal/clock"
 require "parallel_report_portal/configuration"

--- a/lib/parallel_report_portal/configuration.rb
+++ b/lib/parallel_report_portal/configuration.rb
@@ -56,13 +56,20 @@ module ParallelReportPortal
     #
     # The initializer will first attempt to load a configuration files called
     # +report_portal.yml+ (case insensitive) in the both the +config+ and current
-    # working directory (the former takes precidence). It will then apply
+    # working directory (the former takes precedence). It will then apply
     # any of the environment variable values.
     def initialize
       load_configuration_file
       ATTRIBUTES.each do |attr|
         env_value = get_env("rp_#{attr.to_s}")
         send(:"#{attr}=", env_value) if env_value
+      end
+
+      # If this is compiled against OpenSSL v3, we need to turn off the exception raising
+      # when the server closes the stream without sending an EOF message in advance
+      if OpenSSL::SSL.const_defined?(:OP_IGNORE_UNEXPECTED_EOF)
+        # Assign the additional parameter with a bitwise 'or' assignment
+        OpenSSL::SSL::SSLContext::DEFAULT_PARAMS[:options] |= OpenSSL::SSL::OP_IGNORE_UNEXPECTED_EOF
       end
     end
 

--- a/lib/parallel_report_portal/version.rb
+++ b/lib/parallel_report_portal/version.rb
@@ -1,3 +1,3 @@
 module ParallelReportPortal
-  VERSION = "2.5.0"
+  VERSION = "2.5.1"
 end


### PR DESCRIPTION
# What

If running against OpenSSL v3, the code now applies an additional options flag to the OpenSSL parameters that prevents it from crashing if an unexpected End of File occurs, such as if it is communicating with a server that is still running a version of OpenSSL from before v3, which made a breaking change to how the connections are managed that can manifest as an unexpected EOF

# Why 

Removes a potential crash when making requests to Report Portal