### PR TITLE
fix: only call launch_finished once | bump: 3.0.2.beta.1

### DIFF
--- a/lib/parallel_report_portal.rb
+++ b/lib/parallel_report_portal.rb
@@ -33,6 +33,11 @@ module ParallelReportPortal
     if ParallelReportPortal.parallel?
       if ParallelTests.first_process?
         ParallelTests.wait_for_other_processes_to_finish
+
+        launch_id = File.read(launch_id_file)
+        response = http_repeater { req_launch_finished(launch_id, clock) }
+        response.success? ? parse_report_link_from_response(response) : force_stop(launch_id, clock)
+
         delete_file(launch_id_file)
         delete_file(hierarchy_file)
       end

--- a/lib/parallel_report_portal/version.rb
+++ b/lib/parallel_report_portal/version.rb
@@ -1,3 +1,3 @@
 module ParallelReportPortal
-  VERSION = "3.0.1"
+  VERSION = "3.0.2.beta.1"
 end

--- a/parallel_report_portal.gemspec
+++ b/parallel_report_portal.gemspec
@@ -41,6 +41,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'faraday-net_http_persistent', '~> 2.1'
   spec.add_runtime_dependency 'faraday-multipart', '~> 1.0', '>= 1.0.4'
   spec.add_runtime_dependency 'parallel_tests', '>= 2.29.1'
-  spec.add_runtime_dependency 'rubytree', '~> 1.0'
+  spec.add_runtime_dependency 'rubytree', '~> 2.0'
   spec.add_runtime_dependency 'net-http-persistent', '~> 4.0'
 end

--- a/spec/parallel_report_portal/cucumber/report_spec.rb
+++ b/spec/parallel_report_portal/cucumber/report_spec.rb
@@ -37,24 +37,6 @@ RSpec.describe ParallelReportPortal::Cucumber::Report do
   context 'handling launch finished events' do
     let(:uuid) { 'b56818b2-391e-4844-8a6e-144afaf504ed' }
 
-    it 'terminates the launch' do
-      report.instance_variable_set(:@launch_id, uuid)
-      expect(ParallelReportPortal).to receive(:req_launch_finished)
-        .with(uuid, 0).once
-      
-      report.launch_finished(0)
-    end
-
-    it 'issues executes a post launch hook' do
-      report.instance_variable_set(:@launch_id, uuid)
-      expect(ParallelReportPortal).to receive(:req_launch_finished)
-
-      called = false
-      ParallelReportPortal.after_launch { called = true }
-      report.launch_finished(0)
-      expect(called).to eq true
-    end
-
     it 'terminates any existing child items before terminating the launch' do
       tree = Tree::TreeNode.new( 'root' )
       tree << Tree::TreeNode.new('child', 'child_node_uuid')
@@ -62,8 +44,6 @@ RSpec.describe ParallelReportPortal::Cucumber::Report do
       report.instance_variable_set(:@launch_id, uuid)
       report.instance_variable_set(:@tree, tree)
 
-      expect(ParallelReportPortal).to receive(:req_launch_finished)
-        .with(uuid, 0).once
       expect(ParallelReportPortal).to receive(:req_feature_finished)
         .with('child_node_uuid', 0).once
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,8 @@ require 'ostruct'
 require 'tree'
 require 'yaml'
 
+require 'pry'
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"


### PR DESCRIPTION
**What's new?**

- HTTP.repeat method -- to continuously retry HTTP calls when BadGateway errors are received 
- launch_finished called once
- bump to 3.0.2.beta.1